### PR TITLE
Fix for #100 Invalid Ajax URL / Wrong Route.

### DIFF
--- a/user_otp/appinfo/routes.php
+++ b/user_otp/appinfo/routes.php
@@ -1,4 +1,4 @@
 <?php
-
+$this->create('user_otp_personalSettings', 'ajax/personalSettings.php')->actionInclude('user_otp/ajax/personalSettings.php');
 $this->create('user_otp_qrcode','qrcode.php')->actionInclude('user_otp/qrcode.php');
 $this->create('user_otp_list_users','list_users')->actionInclude('user_otp/list_users.php');


### PR DESCRIPTION
It was not possible to create a new OTP seed because the javascript does not found the ajax/personalSettings.php file.

I have created a new route and now the plugin works with Owncloud 8.0 - no other problems found on my installation.

Fix for #100.