### PR TITLE
Skiphosts

### DIFF
--- a/user_otp/adminSettings.php
+++ b/user_otp/adminSettings.php
@@ -150,6 +150,11 @@ $configOtp[$i]['label']='Used password field only and add OTP after the password
 $configOtp[$i]['type']='checkbox';
 $configOtp[$i]['default_value']=false; $i++;
 
+$configOtp[$i]['name']='exceptForThisHosts'; 
+$configOtp[$i]['label']='Skip otp for these hosts ( comma separated )';
+$configOtp[$i]['type']='text';
+$configOtp[$i]['default_value']='localhost'; $i++;
+
 foreach ($allTab as $tab){
     foreach ($$tab["arrayConf"] as $input){
         switch ($input['type']){

--- a/user_otp/lib/otp.php
+++ b/user_otp/lib/otp.php
@@ -248,7 +248,7 @@ class OC_USER_OTP extends OC_User_Backend{
 			return $userBackend->checkPassword($uid, $password);
 		}
 
-        $bypass_hosts = array_map('trim', explode(';', OCP\Config::getAppValue('user_otp','exceptForThisHosts',"localhost")));
+        $bypass_hosts = array_map('trim', explode(',', OCP\Config::getAppValue('user_otp','exceptForThisHosts',"localhost")));
         foreach ($bypass_hosts as &$single_host) {
                 if ($single_host!=null && isset($_SERVER['REMOTE_ADDR'])) {
                         OC_Log::write('OC_USER_OTP','Checking \''.$_SERVER['REMOTE_ADDR'].'\' against \''.$single_host.'\'', OC_Log::DEBUG);

--- a/user_otp/lib/otp.php
+++ b/user_otp/lib/otp.php
@@ -248,6 +248,17 @@ class OC_USER_OTP extends OC_User_Backend{
 			return $userBackend->checkPassword($uid, $password);
 		}
 
+        $bypass_hosts = array_map('trim', explode(';', OCP\Config::getAppValue('user_otp','exceptForThisHosts',"localhost")));
+        foreach ($bypass_hosts as &$single_host) {
+                if ($single_host!=null && isset($_SERVER['REMOTE_ADDR'])) {
+                        OC_Log::write('OC_USER_OTP','Checking \''.$_SERVER['REMOTE_ADDR'].'\' against \''.$single_host.'\'', OC_Log::DEBUG);
+                        if (gethostbyname($single_host) ===  $_SERVER['REMOTE_ADDR'] ) {
+                                OC_Log::write('OC_USER_OTP','Skipping OTP for '.$uid.' from \''.$single_host.'\' ('.$_SERVER['REMOTE_ADDR'].')', OC_Log::INFO);
+                                return $userBackend->checkPassword($uid, $password);
+                        }
+                }
+        }
+
         if(!$this->mOtp->CheckUserExists($uid)){
             OC_Log::write('OC_USER_OTP','No OTP for user '.$uid.' use user backend', OC_Log::DEBUG);
             return $userBackend->checkPassword($uid, $password);


### PR DESCRIPTION
Add support to skip otp for predefined hostnames;
By default it wont use OTP to authenticate if the source address is 'localhost', so you will always be able to login from the localhost using the password.
It accepts multiple hostnames , so you can set clientnames which can login skipping otp.

 